### PR TITLE
add translations for european, korean, chinese and japanese

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Nastavení</string>
+    <string name="about">O aplikaci</string>
+    <string name="apps">Aplikace</string>
+
+    <string name="button_sources_text">Zobrazit zdrojový kód</string>
+
+    <string name="start_on_boot">Spustit Rotation Control při startu systému</string>
+    <string name="forced_mode">Vynutit orientaci obrazovky</string>
+
+    <string name="notice_text">Upozornění</string>
+    <string name="show_notifications_permission_text">Pro správné fungování aplikace je vyžadováno oprávnění k zobrazování oznámení</string>
+    <string name="can_write_settings_permission_text">Pro správné fungování aplikace je vyžadováno oprávnění ke změně systémových nastavení</string>
+    <string name="draw_overlay_permission_text">Režim vynucené orientace obrazovky je aktivní. Pro správné fungování aplikace je vyžadováno oprávnění k zobrazení přes ostatní aplikace</string>
+    <string name="rotation_control_version">Verze aplikace: %s</string>
+
+    <string name="cant_request_permission">Nelze požádat o oprávnění</string>
+    <string name="cant_request_permission_message">Něco se pokazilo. Rotation Control nemohl požádat o potřebná oprávnění</string>
+
+    <string name="stop_service">Zastavit službu</string>
+
+    <string name="service_starting">Služba se spouští…</string>
+    <string name="service_startup_error">Chyba při spouštění služby</string>
+    <string name="permissions_not_granted">Potřebná oprávnění nebyla udělena. Otevřete aplikaci a udělte je</string>
+
+    <string name="boot_start_channel_name">Spuštění při startu</string>
+    <string name="boot_start_prompt">Klepnutím spustíte Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Einstellungen</string>
+    <string name="about">Über die App</string>
+    <string name="apps">Apps</string>
+
+    <string name="button_sources_text">Quellcode anzeigen</string>
+
+    <string name="start_on_boot">Rotation Control beim Systemstart starten</string>
+    <string name="forced_mode">Ausrichtung erzwingen</string>
+
+    <string name="notice_text">Hinweis</string>
+    <string name="show_notifications_permission_text">Für die korrekte Funktion der App ist die Berechtigung zum Anzeigen von Benachrichtigungen erforderlich</string>
+    <string name="can_write_settings_permission_text">Damit die App ordnungsgemäß funktioniert, ist die Berechtigung zum Ändern der Systemeinstellungen erforderlich</string>
+    <string name="draw_overlay_permission_text">Der Modus für die erzwungene Bildschirmausrichtung ist aktiviert. Für die korrekte Funktion der App ist die Berechtigung zur Anzeige über anderen Apps erforderlich</string>
+    <string name="rotation_control_version">App-Version: %s</string>
+
+    <string name="cant_request_permission">Berechtigungen können nicht angefordert werden</string>
+    <string name="cant_request_permission_message">Etwas ist schiefgelaufen. Rotation Control konnte die erforderlichen Berechtigungen nicht anfordern</string>
+
+    <string name="stop_service">Dienst beenden</string>
+
+    <string name="service_starting">Dienst wird gestartet…</string>
+    <string name="service_startup_error">Fehler beim Starten des Dienstes</string>
+    <string name="permissions_not_granted">Erforderliche Berechtigungen wurden nicht erteilt. Öffnen Sie die App und erteilen Sie sie</string>
+
+    <string name="boot_start_channel_name">Start beim Systemstart</string>
+    <string name="boot_start_prompt">Tippen, um Rotation Control zu starten</string>
+
+</resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Ajustes</string>
+    <string name="about">Acerca de</string>
+    <string name="apps">Aplicaciones</string>
+
+    <string name="button_sources_text">Ver código fuente</string>
+
+    <string name="start_on_boot">Iniciar Rotation Control al arrancar el sistema</string>
+    <string name="forced_mode">Forzar la orientación</string>
+
+    <string name="notice_text">Aviso</string>
+    <string name="show_notifications_permission_text">Para que la aplicación funcione correctamente, se requiere permiso para mostrar notificaciones</string>
+    <string name="can_write_settings_permission_text">Para que la aplicación funcione correctamente, se requiere permiso para modificar los ajustes del sistema</string>
+    <string name="draw_overlay_permission_text">El modo de orientación forzada de la pantalla está activado. Para que la aplicación funcione correctamente, se requiere permiso para mostrarse sobre otras aplicaciones</string>
+    <string name="rotation_control_version">Versión de la aplicación: %s</string>
+
+    <string name="cant_request_permission">No se pueden solicitar los permisos</string>
+    <string name="cant_request_permission_message">Algo salió mal. Rotation Control no pudo solicitar los permisos necesarios</string>
+
+    <string name="stop_service">Detener el servicio</string>
+
+    <string name="service_starting">El servicio se está iniciando…</string>
+    <string name="service_startup_error">Error al iniciar el servicio</string>
+    <string name="permissions_not_granted">No se han concedido los permisos necesarios. Abre la aplicación y concédelos</string>
+
+    <string name="boot_start_channel_name">Inicio al arrancar</string>
+    <string name="boot_start_prompt">Toca para iniciar Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Paramètres</string>
+    <string name="about">À propos</string>
+    <string name="apps">Applications</string>
+
+    <string name="button_sources_text">Voir les sources</string>
+
+    <string name="start_on_boot">Démarrer Rotation Control au démarrage du système</string>
+    <string name="forced_mode">Forcer l\'orientation</string>
+
+    <string name="notice_text">Avis</string>
+    <string name="show_notifications_permission_text">Pour que l\'application fonctionne correctement, l\'autorisation d\'afficher des notifications est requise</string>
+    <string name="can_write_settings_permission_text">Pour que l\'application fonctionne correctement, l\'autorisation de modifier les paramètres système est requise</string>
+    <string name="draw_overlay_permission_text">Le mode d\'orientation forcée de l\'écran est activé. Pour que l\'application fonctionne correctement, l\'autorisation d\'affichage par-dessus les autres applications est requise</string>
+    <string name="rotation_control_version">Version de l\'application : %s</string>
+
+    <string name="cant_request_permission">Impossible de demander les autorisations</string>
+    <string name="cant_request_permission_message">Une erreur s\'est produite. Rotation Control n\'a pas pu demander les autorisations nécessaires</string>
+
+    <string name="stop_service">Arrêter le service</string>
+
+    <string name="service_starting">Démarrage du service…</string>
+    <string name="service_startup_error">Erreur de démarrage du service</string>
+    <string name="permissions_not_granted">Les autorisations requises ne sont pas accordées. Ouvrez l\'application et accordez-les</string>
+
+    <string name="boot_start_channel_name">Lancement au démarrage</string>
+    <string name="boot_start_prompt">Appuyez pour démarrer Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Impostazioni</string>
+    <string name="about">Informazioni</string>
+    <string name="apps">App</string>
+
+    <string name="button_sources_text">Visualizza il codice sorgente</string>
+
+    <string name="start_on_boot">Avvia Rotation Control all\'avvio del sistema</string>
+    <string name="forced_mode">Forza l\'orientamento</string>
+
+    <string name="notice_text">Avviso</string>
+    <string name="show_notifications_permission_text">Per il corretto funzionamento dell\'app è necessaria l\'autorizzazione a mostrare le notifiche</string>
+    <string name="can_write_settings_permission_text">Per il corretto funzionamento dell\'app è necessaria l\'autorizzazione a modificare le impostazioni di sistema</string>
+    <string name="draw_overlay_permission_text">La modalità di orientamento forzato dello schermo è attiva. Per il corretto funzionamento dell\'app è necessaria l\'autorizzazione a sovrapporsi ad altre app</string>
+    <string name="rotation_control_version">Versione dell\'app: %s</string>
+
+    <string name="cant_request_permission">Impossibile richiedere le autorizzazioni</string>
+    <string name="cant_request_permission_message">Si è verificato un errore. Rotation Control non è riuscito a richiedere le autorizzazioni necessarie</string>
+
+    <string name="stop_service">Arresta il servizio</string>
+
+    <string name="service_starting">Avvio del servizio in corso…</string>
+    <string name="service_startup_error">Errore di avvio del servizio</string>
+    <string name="permissions_not_granted">Le autorizzazioni necessarie non sono state concesse. Apri l\'app e concedile</string>
+
+    <string name="boot_start_channel_name">Avvio all\'accensione</string>
+    <string name="boot_start_prompt">Tocca per avviare Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">設定</string>
+    <string name="about">このアプリについて</string>
+    <string name="apps">アプリ</string>
+
+    <string name="button_sources_text">ソースコードを表示</string>
+
+    <string name="start_on_boot">システム起動時に Rotation Control を起動する</string>
+    <string name="forced_mode">画面の向きを強制する</string>
+
+    <string name="notice_text">注意</string>
+    <string name="show_notifications_permission_text">アプリが正しく動作するには、通知を表示する権限が必要です</string>
+    <string name="can_write_settings_permission_text">アプリが正しく動作するには、システム設定を変更する権限が必要です</string>
+    <string name="draw_overlay_permission_text">画面の向きを強制するモードが有効です。アプリが正しく動作するには、他のアプリの上に表示する権限が必要です</string>
+    <string name="rotation_control_version">アプリのバージョン: %s</string>
+
+    <string name="cant_request_permission">権限をリクエストできません</string>
+    <string name="cant_request_permission_message">問題が発生しました。Rotation Control は必要な権限をリクエストできませんでした</string>
+
+    <string name="stop_service">サービスを停止</string>
+
+    <string name="service_starting">サービスを開始しています…</string>
+    <string name="service_startup_error">サービスの起動エラー</string>
+    <string name="permissions_not_granted">必要な権限が許可されていません。アプリを開いて許可してください</string>
+
+    <string name="boot_start_channel_name">起動時に開始</string>
+    <string name="boot_start_prompt">タップして Rotation Control を起動</string>
+
+</resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">설정</string>
+    <string name="about">정보</string>
+    <string name="apps">앱</string>
+
+    <string name="button_sources_text">소스 코드 보기</string>
+
+    <string name="start_on_boot">시스템 부팅 시 Rotation Control 시작</string>
+    <string name="forced_mode">화면 방향 강제 적용</string>
+
+    <string name="notice_text">안내</string>
+    <string name="show_notifications_permission_text">앱이 올바르게 작동하려면 알림 표시 권한이 필요합니다</string>
+    <string name="can_write_settings_permission_text">앱이 올바르게 작동하려면 시스템 설정을 변경할 수 있는 권한이 필요합니다</string>
+    <string name="draw_overlay_permission_text">화면 방향 강제 적용 모드가 활성화되어 있습니다. 앱이 올바르게 작동하려면 다른 앱 위에 표시할 수 있는 권한이 필요합니다</string>
+    <string name="rotation_control_version">앱 버전: %s</string>
+
+    <string name="cant_request_permission">권한을 요청할 수 없습니다</string>
+    <string name="cant_request_permission_message">문제가 발생했습니다. Rotation Control에서 필요한 권한을 요청할 수 없습니다</string>
+
+    <string name="stop_service">서비스 중지</string>
+
+    <string name="service_starting">서비스를 시작하는 중…</string>
+    <string name="service_startup_error">서비스 시작 오류</string>
+    <string name="permissions_not_granted">필요한 권한이 부여되지 않았습니다. 앱을 열고 권한을 부여하세요</string>
+
+    <string name="boot_start_channel_name">부팅 시 시작</string>
+    <string name="boot_start_prompt">Rotation Control을 시작하려면 탭하세요</string>
+
+</resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Instellingen</string>
+    <string name="about">Over</string>
+    <string name="apps">Apps</string>
+
+    <string name="button_sources_text">Broncode bekijken</string>
+
+    <string name="start_on_boot">Rotation Control starten bij het opstarten van het systeem</string>
+    <string name="forced_mode">Oriëntatie afdwingen</string>
+
+    <string name="notice_text">Let op</string>
+    <string name="show_notifications_permission_text">Voor een goede werking van de app is toestemming om meldingen weer te geven vereist</string>
+    <string name="can_write_settings_permission_text">Voor een goede werking van de app is toestemming om systeeminstellingen te wijzigen vereist</string>
+    <string name="draw_overlay_permission_text">De modus voor geforceerde schermoriëntatie is ingeschakeld. Voor een goede werking van de app is toestemming om over andere apps weer te geven vereist</string>
+    <string name="rotation_control_version">App-versie: %s</string>
+
+    <string name="cant_request_permission">Kan geen toestemmingen aanvragen</string>
+    <string name="cant_request_permission_message">Er is iets misgegaan. Rotation Control kon de benodigde toestemmingen niet aanvragen</string>
+
+    <string name="stop_service">Service stoppen</string>
+
+    <string name="service_starting">Service wordt gestart…</string>
+    <string name="service_startup_error">Fout bij het starten van de service</string>
+    <string name="permissions_not_granted">De vereiste toestemmingen zijn niet verleend. Open de app en verleen ze</string>
+
+    <string name="boot_start_channel_name">Starten bij opstarten</string>
+    <string name="boot_start_prompt">Tik om Rotation Control te starten</string>
+
+</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Ustawienia</string>
+    <string name="about">O aplikacji</string>
+    <string name="apps">Aplikacje</string>
+
+    <string name="button_sources_text">Zobacz kod źródłowy</string>
+
+    <string name="start_on_boot">Uruchamiaj Rotation Control przy starcie systemu</string>
+    <string name="forced_mode">Wymuszanie orientacji ekranu</string>
+
+    <string name="notice_text">Uwaga</string>
+    <string name="show_notifications_permission_text">Do poprawnego działania aplikacja wymaga uprawnienia do wyświetlania powiadomień</string>
+    <string name="can_write_settings_permission_text">Do poprawnego działania aplikacja wymaga uprawnienia do zmiany ustawień systemowych</string>
+    <string name="draw_overlay_permission_text">Tryb wymuszonej orientacji ekranu jest włączony. Do poprawnego działania aplikacja wymaga uprawnienia do wyświetlania nad innymi aplikacjami</string>
+    <string name="rotation_control_version">Wersja aplikacji: %s</string>
+
+    <string name="cant_request_permission">Nie można poprosić o uprawnienia</string>
+    <string name="cant_request_permission_message">Coś poszło nie tak. Rotation Control nie mógł poprosić o niezbędne uprawnienia</string>
+
+    <string name="stop_service">Zatrzymaj usługę</string>
+
+    <string name="service_starting">Uruchamianie usługi…</string>
+    <string name="service_startup_error">Błąd uruchamiania usługi</string>
+    <string name="permissions_not_granted">Nie przyznano wymaganych uprawnień. Otwórz aplikację i przyznaj je</string>
+
+    <string name="boot_start_channel_name">Uruchamianie przy starcie</string>
+    <string name="boot_start_prompt">Dotknij, aby uruchomić Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Configurações</string>
+    <string name="about">Sobre</string>
+    <string name="apps">Aplicativos</string>
+
+    <string name="button_sources_text">Ver código-fonte</string>
+
+    <string name="start_on_boot">Iniciar o Rotation Control ao ligar o sistema</string>
+    <string name="forced_mode">Forçar a orientação</string>
+
+    <string name="notice_text">Aviso</string>
+    <string name="show_notifications_permission_text">Para que o aplicativo funcione corretamente, é necessária a permissão para exibir notificações</string>
+    <string name="can_write_settings_permission_text">Para que o aplicativo funcione corretamente, é necessária a permissão para alterar as configurações do sistema</string>
+    <string name="draw_overlay_permission_text">O modo de orientação forçada da tela está ativado. Para que o aplicativo funcione corretamente, é necessária a permissão para sobreposição sobre outros aplicativos</string>
+    <string name="rotation_control_version">Versão do aplicativo: %s</string>
+
+    <string name="cant_request_permission">Não é possível solicitar as permissões</string>
+    <string name="cant_request_permission_message">Algo deu errado. O Rotation Control não conseguiu solicitar as permissões necessárias</string>
+
+    <string name="stop_service">Parar o serviço</string>
+
+    <string name="service_starting">O serviço está iniciando…</string>
+    <string name="service_startup_error">Erro ao iniciar o serviço</string>
+    <string name="permissions_not_granted">As permissões necessárias não foram concedidas. Abra o aplicativo e conceda-as</string>
+
+    <string name="boot_start_channel_name">Início ao ligar</string>
+    <string name="boot_start_prompt">Toque para iniciar o Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Inställningar</string>
+    <string name="about">Om</string>
+    <string name="apps">Appar</string>
+
+    <string name="button_sources_text">Visa källkod</string>
+
+    <string name="start_on_boot">Starta Rotation Control vid systemstart</string>
+    <string name="forced_mode">Tvinga skärmorientering</string>
+
+    <string name="notice_text">Observera</string>
+    <string name="show_notifications_permission_text">För att appen ska fungera korrekt krävs behörighet att visa aviseringar</string>
+    <string name="can_write_settings_permission_text">För att appen ska fungera korrekt krävs behörighet att ändra systeminställningar</string>
+    <string name="draw_overlay_permission_text">Läget för tvingad skärmorientering är aktiverat. För att appen ska fungera korrekt krävs behörighet att visas ovanpå andra appar</string>
+    <string name="rotation_control_version">Appversion: %s</string>
+
+    <string name="cant_request_permission">Det går inte att begära behörigheter</string>
+    <string name="cant_request_permission_message">Något gick fel. Rotation Control kunde inte begära de nödvändiga behörigheterna</string>
+
+    <string name="stop_service">Stoppa tjänsten</string>
+
+    <string name="service_starting">Tjänsten startar…</string>
+    <string name="service_startup_error">Fel vid start av tjänsten</string>
+    <string name="permissions_not_granted">De nödvändiga behörigheterna har inte beviljats. Öppna appen och bevilja dem</string>
+
+    <string name="boot_start_channel_name">Start vid systemstart</string>
+    <string name="boot_start_prompt">Tryck för att starta Rotation Control</string>
+
+</resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">Ayarlar</string>
+    <string name="about">Hakkında</string>
+    <string name="apps">Uygulamalar</string>
+
+    <string name="button_sources_text">Kaynak kodu görüntüle</string>
+
+    <string name="start_on_boot">Sistem açıldığında Rotation Control\'ü başlat</string>
+    <string name="forced_mode">Ekran yönünü zorla uygula</string>
+
+    <string name="notice_text">Uyarı</string>
+    <string name="show_notifications_permission_text">Uygulamanın düzgün çalışması için bildirim gösterme izni gereklidir</string>
+    <string name="can_write_settings_permission_text">Uygulamanın düzgün çalışması için sistem ayarlarını değiştirme izni gereklidir</string>
+    <string name="draw_overlay_permission_text">Zorunlu ekran yönü modu etkin. Uygulamanın düzgün çalışması için diğer uygulamaların üzerinde gösterme izni gereklidir</string>
+    <string name="rotation_control_version">Uygulama sürümü: %s</string>
+
+    <string name="cant_request_permission">İzinler istenemiyor</string>
+    <string name="cant_request_permission_message">Bir şeyler ters gitti. Rotation Control gerekli izinleri isteyemedi</string>
+
+    <string name="stop_service">Hizmeti durdur</string>
+
+    <string name="service_starting">Hizmet başlatılıyor…</string>
+    <string name="service_startup_error">Hizmet başlatma hatası</string>
+    <string name="permissions_not_granted">Gerekli izinler verilmedi. Uygulamayı açıp izinleri verin</string>
+
+    <string name="boot_start_channel_name">Açılışta başlatma</string>
+    <string name="boot_start_prompt">Rotation Control\'ü başlatmak için dokunun</string>
+
+</resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="settings">设置</string>
+    <string name="about">关于</string>
+    <string name="apps">应用</string>
+
+    <string name="button_sources_text">查看源代码</string>
+
+    <string name="start_on_boot">系统启动时启动 Rotation Control</string>
+    <string name="forced_mode">强制应用屏幕方向</string>
+
+    <string name="notice_text">注意</string>
+    <string name="show_notifications_permission_text">为使应用正常运行，需要显示通知的权限</string>
+    <string name="can_write_settings_permission_text">为使应用正常运行，需要修改系统设置的权限</string>
+    <string name="draw_overlay_permission_text">已启用强制屏幕方向模式。为使应用正常运行，需要在其他应用上层显示的权限</string>
+    <string name="rotation_control_version">应用版本：%s</string>
+
+    <string name="cant_request_permission">无法请求权限</string>
+    <string name="cant_request_permission_message">出了点问题。Rotation Control 无法请求所需的权限</string>
+
+    <string name="stop_service">停止服务</string>
+
+    <string name="service_starting">正在启动服务…</string>
+    <string name="service_startup_error">服务启动错误</string>
+    <string name="permissions_not_granted">未授予所需权限。请打开应用并授予权限</string>
+
+    <string name="boot_start_channel_name">开机启动</string>
+    <string name="boot_start_prompt">点按以启动 Rotation Control</string>
+
+</resources>


### PR DESCRIPTION
localize all 19 user-facing strings into de, fr, es, it, pt, nl, pl, tr, sv, cs (european), plus ko, ja and zh-rCN. brand name "Rotation Control" is left untranslated; %s placeholder and the ellipsis are preserved.