### PR TITLE
fix: fragment commit after onSaveInstanceState

### DIFF
--- a/app/src/main/java/com/arttttt/rotationcontrolv3/ui/main2/platform/MainFragment2.kt
+++ b/app/src/main/java/com/arttttt/rotationcontrolv3/ui/main2/platform/MainFragment2.kt
@@ -140,6 +140,10 @@ class MainFragment2(
     }
 
     private fun setFragment(item: MenuItem) {
+        if (childFragmentManager.isStateSaved) {
+            return
+        }
+
         when (item) {
             MenuItem.Settings -> {
                 childFragmentManager.commit {


### PR DESCRIPTION
## Problem

`IllegalStateException: Can not perform this action after onSaveInstanceState` from Crashlytics. Stack path:

```
NavigationBarView.onMenuItemSelected
  -> MainViewImpl.dispatch (BottomNavigationClicked)
  -> mvikotlin channel (async hop)
  -> MainController navigation binding (uiState.selectedMenuItem)
  -> MainFragment2.onSetMenuItem -> setFragment
  -> childFragmentManager.commit
  -> FragmentManager.checkStateLoss  💥
```

The bottom-nav click travels an asynchronous MVI pipeline (a buffered channel + a `StateFlow`/`distinctUntilChanged` hop). Between the tap and the actual `commit()` the activity can call `onSaveInstanceState`, so the strict `commit()` throws.

## Root cause

`setFragment` committed unconditionally. There is one asynchronous suspension point between the user tap and `commit()`, during which the activity state becomes saved.

## Fix

Guard `setFragment` with `isStateSaved` and return early — drop the navigation if it lands in the saved-state window:

```kotlin
private fun setFragment(item: MenuItem) {
    if (childFragmentManager.isStateSaved) {
        return
    }
    when (item) { ... childFragmentManager.commit { replace<...>(R.id.container) } }
}
```

### Why `isStateSaved` is a watertight gate

Verified against `fragment 1.6.2` sources:

```java
// FragmentManager.java
private void checkStateLoss() {
    if (isStateSaved()) {
        throw new IllegalStateException("Can not perform this action after onSaveInstanceState");
    }
}

public boolean isStateSaved() {
    return mStateSaved || mStopped;   // mStopped is already OR'd in
}
```

So `!isStateSaved()` is the exact inverse of the throw condition. It covers:
- the pre-28 `onSaveInstanceState` window (where the view lifecycle is still `STARTED`, so a lifecycle-based gate would *not* be safe — that's why we don't gate on `isAtLeast(STARTED)`), and
- the 28+ `onStop`-before-`onSaveInstanceState` window (covered via `mStopped`).

The gate and `checkStateLoss()` run synchronously on the main thread with no yield point between them → no TOCTOU, so **strict `commit()` stays safe and there is zero state loss** (no `allowStateLoss` needed).

## Behavior in the saved-state window

If the tap lands exactly in the saved-state window, the navigation is dropped. `uiState.selectedMenuItem` is updated *before* `setFragment` runs, so on return the bottom-nav visually shows the tapped tab while the child container still shows the previous one — a transient mismatch the user resolves by tapping the tab again. Accepted as a rare edge case in exchange for a minimal, state-loss-free fix.

## Scope

`setFragment` is the only `childFragmentManager.commit` site in `MainFragment2`. No changes to `MainController`, `MainViewImpl`, the binder mode, or the `MenuItem` model. 1 file, +4 lines.

## Verification

- `:app:compileDebugKotlin` passes.
- Repro to run before merge: tap a bottom-nav tab and immediately background the app → no crash.

🤖 Generated with [OpenCode](https://opencode.ai) (Glm-5.2)